### PR TITLE
caches: update for LLVM

### DIFF
--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -127,12 +127,10 @@ set(LLDB_TOOLS
       lldb-argdumper
       lldb-python-scripts
       lldb-server
-      lldb-dap
-      repl_swift
+      lldb-vscode
     CACHE STRING "")
 
 set(LLVM_DISTRIBUTION_COMPONENTS
-      IndexStore
       libclang
       libclang-headers
       LTO

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -127,12 +127,10 @@ set(LLDB_TOOLS
       lldb-argdumper
       lldb-python-scripts
       lldb-server
-      lldb-dap
-      repl_swift
+      lldb-vscode
     CACHE STRING "")
 
 set(LLVM_DISTRIBUTION_COMPONENTS
-      IndexStore
       libclang
       libclang-headers
       LTO


### PR DESCRIPTION
remove IndexStore, repl_swift; rename lldb-dap to the old name of lldb-vscode.