### PR TITLE
Remove cross compilation and enable more architectures

### DIFF
--- a/.github/actions/build-tools/action.yml
+++ b/.github/actions/build-tools/action.yml
@@ -27,11 +27,11 @@ runs:
         path: ${{ github.workspace }}/SourceCache/llvm-project
         show-progress: false
 
-    - name: Setup Ninja
-      if: steps.cache-built-tools.outputs.cache-hit != 'true'
-      uses: seanmiddleditch/gha-setup-ninja@master
+    - name: Get latest CMake and Ninja
+      uses: lukka/get-cmake@latest
       with:
-        version: 1.13.1
+        ninjaVersion: 1.13.2
+        cmakeVersion: 4.2.0
 
     # - name: Setup sccache
     #   uses: compnerd/ccache-action@sccache-0.7.4

--- a/.github/actions/build-tools/action.yml
+++ b/.github/actions/build-tools/action.yml
@@ -14,9 +14,9 @@ runs:
         path: |
           ${{ github.workspace }}/BinaryCache/0
           ${{ github.workspace }}/SourceCache/llvm-project
-        key: build-tools-${{ runner.os }}-{ runner.arch }-${{ inputs.llvm_version }}-${{ hashFiles('.github/actions/build-tools/action.yml') }}
+        key: build-tools-${{ runner.os }}-${{ runner.arch }}-${{ inputs.llvm_version }}-${{ hashFiles('.github/actions/build-tools/action.yml') }}
         restore-keys: |
-          build-tools-${{ runner.os }}-{ runner.arch }-
+          build-tools-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Checkout LLVM sources
       uses: actions/checkout@v4

--- a/.github/actions/build-tools/action.yml
+++ b/.github/actions/build-tools/action.yml
@@ -31,7 +31,7 @@ runs:
       if: steps.cache-built-tools.outputs.cache-hit != 'true'
       uses: seanmiddleditch/gha-setup-ninja@master
       with:
-        version: 1.11.1
+        version: 1.13.1
 
     # - name: Setup sccache
     #   uses: compnerd/ccache-action@sccache-0.7.4

--- a/.github/actions/build-tools/action.yml
+++ b/.github/actions/build-tools/action.yml
@@ -27,7 +27,7 @@ runs:
         path: ${{ github.workspace }}/SourceCache/llvm-project
         show-progress: false
 
-    - name: Get latest CMake and Ninja
+    - name: Install CMake and Ninja
       uses: lukka/get-cmake@latest
       with:
         ninjaVersion: 1.13.2

--- a/.github/workflows/llvm-binaries.yml
+++ b/.github/workflows/llvm-binaries.yml
@@ -363,7 +363,7 @@ jobs:
           
           # Test llvm-config
           echo "Testing llvm-config..."
-          ${{ github.workspace }}/BuildRoot/${{ env.PACKAGE_NAME }}/bin/llvm-config${{ matrix.executable_suffix }} --version
+          "${{ github.workspace }}/BuildRoot/${{ env.PACKAGE_NAME }}/bin/llvm-config${{ matrix.executable_suffix }}" --version
 
       - name: Make llvm.pc pkg-config file
         shell: bash

--- a/.github/workflows/llvm-binaries.yml
+++ b/.github/workflows/llvm-binaries.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   create_tag:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       tag_name: ${{ steps.timestamp.outputs.time }}
 
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [windows-2025, macos-15, ubuntu-22.04]
+        os: [windows-2025, macos-15, ubuntu-24.04]
         arch: [x86_64, arm64]
         configuration: [Debug, MinSizeRel]
 
@@ -96,21 +96,11 @@ jobs:
 
           - arch: arm64
 
-            cmake_find_root_path_option: >-
-              -D CMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER
-              -D CMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY
-              -D CMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY
-              -D CMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY
-            cmake_system_processor_option: -D CMAKE_SYSTEM_PROCESSOR=arm64
-            llvm_target_arch_option: -D LLVM_TARGET_ARCH=arm64
             triple_cpu: arm64
 
           - arch: arm64
-            os: ubuntu-22.04
+            os: ubuntu-24.04
 
-            cmake_system_processor_option: -D CMAKE_SYSTEM_PROCESSOR=aarch64
-            c_compiler: aarch64-linux-gnu-gcc
-            cxx_compiler: aarch64-linux-gnu-g++
             triple_cpu: aarch64
 
           - arch: arm64
@@ -140,7 +130,7 @@ jobs:
             cmake_system_name: Windows
             triple_suffix: unknown-windows-msvc17
 
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
 
             cmake_system_name: Linux
             triple_suffix: unknown-linux-gnu
@@ -150,13 +140,34 @@ jobs:
             cmake_system_name: Darwin
             triple_suffix: apple-darwin24.1.0
 
-    runs-on: ${{ matrix.os }}
+          # Runner mapping for architecture-specific runners
+          - os: ubuntu-24.04
+            arch: x86_64
+            runner: ubuntu-24.04
+
+          - os: ubuntu-24.04
+            arch: arm64
+            runner: ubuntu-24.04-arm
+
+          - os: macos-15
+            arch: x86_64
+            runner: macos-15-intel
+
+          - os: macos-15
+            arch: arm64
+            runner: macos-15
+
+          - os: windows-2025
+            arch: x86_64
+            runner: windows-2025
+
+          - os: windows-2025
+            arch: arm64
+            runner: windows-11-arm
+
+    runs-on: ${{ matrix.runner }}
 
     env:
-      cmake_c_compiler_target_option: ${{ matrix.arch != 'x86_64' && format('-D CMAKE_C_COMPILER_TARGET={0}-{1}', matrix.triple_cpu, matrix.triple_suffix) || '' }}
-      cmake_cxx_compiler_target_option: ${{ matrix.arch != 'x86_64' && format('-D CMAKE_CXX_COMPILER_TARGET={0}-{1}', matrix.triple_cpu, matrix.triple_suffix) || '' }}
-      cmake_system_name_option: ${{ matrix.arch != 'x86_64' && format('-D CMAKE_SYSTEM_NAME={0}', matrix.cmake_system_name) || '' }}
-      llvm_host_triple_option: ${{ matrix.arch != 'x86_64' && format('-D LLVM_HOST_TRIPLE={0}-{1}', matrix.triple_cpu, matrix.triple_suffix) || '' }}
       PACKAGE_NAME: llvm-${{ github.event.inputs.llvm_version }}-${{ matrix.triple_cpu }}-${{ matrix.triple_suffix }}-${{ matrix.configuration }}
 
     steps:
@@ -238,24 +249,6 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: brew install zstd
 
-      - name: Cross-build prerequisites (ubuntu)
-        if: ${{ runner.os == 'Linux' && matrix.arch != 'x86_64' }}
-        run: |
-          sudo dpkg --add-architecture arm64
-
-          # See answer #4 at https://answers.launchpad.net/ubuntu/+source/apt/+question/661407
-          sudo cp /etc/apt/sources.list /etc/apt/sources.list.bak
-          sudo sed -E \
-          -e 's#^deb[[:space:]]+([^[:space:]]+)[[:space:]]+(.*)#deb [arch=amd64,i386] \1 \2\ndeb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ \2#g' \
-          -e 's/^# deb-src /deb-src /' \
-          -e 'w /etc/apt/sources.list' \
-          /etc/apt/sources.list.bak
-          cat /etc/apt/sources.list
-
-          sudo apt-get update
-          sudo apt-get build-dep -a arm64 llvm
-          sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-
       - name: Configure LLVM
         run: >-
           cmake -GNinja
@@ -265,18 +258,13 @@ jobs:
           -C ${{ github.workspace }}/SourceCache/llvm-build/cmake/caches/LLVM.cmake
           -D CMAKE_C_COMPILER=${{ matrix.c_compiler }}
           -D CMAKE_C_COMPILER_LAUNCHER=sccache
-          ${{ env.cmake_c_compiler_target_option }}
           -D CMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }}
           -D CMAKE_CXX_COMPILER_LAUNCHER=sccache
-          ${{ env.cmake_cxx_compiler_target_option }}
-          ${{ matrix.cmake_find_root_path_option }}
           -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
           ${{ matrix.cmake_debug_options }}
           -D CMAKE_MT=mt
           -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/${{ env.PACKAGE_NAME }}
-          ${{ env.cmake_system_name_option }}
           ${{ matrix.cmake_msvc_options }}
-          ${{ matrix.cmake_system_processor_option }}
           -D LLVM_DISTRIBUTION_COMPONENTS="${{ matrix.llvm_backend_libs }};LLVMAggressiveInstCombine;LLVMAnalysis;LLVMAsmParser;LLVMAsmPrinter;LLVMBinaryFormat;LLVMBitReader;LLVMBitWriter;LLVMBitstreamReader;LLVMCFGuard;LLVMCGData;LLVMCodeGen;LLVMCodeGenTypes;LLVMCore;LLVMCoroutines;LLVMDebugInfoBTF;LLVMDebugInfoCodeView;LLVMDebugInfoDWARF;LLVMDebugInfoMSF;LLVMDebugInfoPDB;LLVMDemangle;LLVMFrontendAtomic;LLVMFrontendOffloading;LLVMFrontendOpenMP;LLVMGlobalISel;LLVMHipStdPar;LLVMIRPrinter;LLVMIRReader;LLVMInstCombine;LLVMInstrumentation;LLVMLinker;LLVMMC;LLVMMCA;LLVMMCDisassembler;LLVMMCParser;LLVMObjCARCOpts;LLVMObject;LLVMPasses;LLVMProfileData;LLVMRemarks;LLVMSandboxIR;LLVMScalarOpts;LLVMSelectionDAG;LLVMSupport;LLVMSymbolize;LLVMTarget;LLVMTargetParser;LLVMTextAPI;LLVMTransformUtils;LLVMVectorize;LLVMipo;llvm-headers;cmake-exports;lld-cmake-exports;${{ matrix.llvm_distribution_tools }}"
           -D LLVM_CONFIG_PATH=${{ github.workspace }}/BinaryCache/0/bin/llvm-config${{ matrix.executable_suffix }}
           -D LLVM_NATIVE_TOOL_DIR=${{ github.workspace }}/BinaryCache/0/bin
@@ -285,9 +273,7 @@ jobs:
           -D PACKAGE_VENDOR=hylo-lang.org
           -D LLVM_APPEND_VC_REV=NO
           -D LLVM_ENABLE_PROJECTS="lld"
-          ${{ env.llvm_host_triple_option }}
           -D LLVM_PARALLEL_LINK_JOBS=2
-          ${{ matrix.llvm_target_arch_option }}
           -D LLVM_VERSION_SUFFIX=""
           ${{ matrix.zstd_root_option }}
 
@@ -362,6 +348,23 @@ jobs:
         working-directory: ${{ github.workspace }}/BuildRoot/${{ env.PACKAGE_NAME }}
         run: |
           pwsh -File ${{ github.workspace }}/SourceCache/llvm-build/scripts/fix-vs.ps1
+
+      - name: Test binary compatibility
+        shell: bash
+        run: |
+          echo "=== Testing Binary Compatibility ==="
+          echo "Runner OS: ${{ runner.os }}"
+          echo "Runner Arch: ${{ runner.arch }}"
+          echo "Target Arch: ${{ matrix.arch }}"
+          echo "Target Triple: ${{ matrix.triple_cpu }}-${{ matrix.triple_suffix }}"
+          echo ""
+          
+          # Test llvm-config
+          echo "Testing llvm-config..."
+          ${{ github.workspace }}/BuildRoot/${{ env.PACKAGE_NAME }}/bin/llvm-config${{ matrix.executable_suffix }} --version          
+          # Test lld
+          echo "Testing lld..."
+          ${{ github.workspace }}/BuildRoot/${{ env.PACKAGE_NAME }}/bin/lld${{ matrix.executable_suffix }} --version
 
       - name: Make llvm.pc pkg-config file
         shell: bash

--- a/.github/workflows/llvm-binaries.yml
+++ b/.github/workflows/llvm-binaries.yml
@@ -83,7 +83,7 @@ jobs:
 
             c_compiler: cl
             # Swift's runtime is compiled this way, and can't be
-            # linked to a C++ binary other settings.
+            # linked to a C++ binary with other settings.
             cmake_msvc_options: -D CMAKE_CXX_FLAGS=-D_ITERATOR_DEBUG_LEVEL=0 -D CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL
             cxx_compiler: cl
             executable_suffix: .exe

--- a/.github/workflows/llvm-binaries.yml
+++ b/.github/workflows/llvm-binaries.yml
@@ -213,7 +213,7 @@ jobs:
         with:
           llvm_version: ${{ env.llvm_version }}
 
-      - name: Get latest CMake and Ninja
+      - name: Install CMake and Ninja
         uses: lukka/get-cmake@latest
         with:
           ninjaVersion: 1.13.2

--- a/.github/workflows/llvm-binaries.yml
+++ b/.github/workflows/llvm-binaries.yml
@@ -213,9 +213,11 @@ jobs:
         with:
           llvm_version: ${{ env.llvm_version }}
 
-      - uses: seanmiddleditch/gha-setup-ninja@master
+      - name: Get latest CMake and Ninja
+        uses: lukka/get-cmake@latest
         with:
-          version: 1.11.1
+          ninjaVersion: 1.13.2
+          cmakeVersion: 4.2.0
 
       - name: Setup sccache
         id: sccache

--- a/.github/workflows/llvm-binaries.yml
+++ b/.github/workflows/llvm-binaries.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Setup sccache
         id: sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: hendrikmuhs/ccache-action@v1.2.20
         with:
           max-size: ${{ matrix.compile_cache_max_size }}
           key: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-package
@@ -363,10 +363,7 @@ jobs:
           
           # Test llvm-config
           echo "Testing llvm-config..."
-          ${{ github.workspace }}/BuildRoot/${{ env.PACKAGE_NAME }}/bin/llvm-config${{ matrix.executable_suffix }} --version          
-          # Test lld
-          echo "Testing lld..."
-          ${{ github.workspace }}/BuildRoot/${{ env.PACKAGE_NAME }}/bin/lld${{ matrix.executable_suffix }} --version
+          ${{ github.workspace }}/BuildRoot/${{ env.PACKAGE_NAME }}/bin/llvm-config${{ matrix.executable_suffix }} --version
 
       - name: Make llvm.pc pkg-config file
         shell: bash

--- a/.github/workflows/llvm-binaries.yml
+++ b/.github/workflows/llvm-binaries.yml
@@ -62,7 +62,6 @@ jobs:
           - compile_cache_max_size: 1G
           - cxx_compiler: clang++
           - executable_suffix:
-          - into_environment: '>> $GITHUB_ENV'
           - llvm_target_arch_option:
           - package_command: tar --zstd -cf
           - package_suffix: .tar.zst
@@ -88,7 +87,6 @@ jobs:
             cmake_msvc_options: -D CMAKE_CXX_FLAGS=-D_ITERATOR_DEBUG_LEVEL=0 -D CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL
             cxx_compiler: cl
             executable_suffix: .exe
-            into_environment: '| Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append'
             static_lib_suffix: .lib
             toolset_suffix: -msvc17
 


### PR DESCRIPTION
Solves issue #31 .

Related PRs for testing the resulting library in other repos: 
- https://github.com/hylo-lang/Swifty-LLVM/pull/111
- https://github.com/hylo-lang/hylo-new/pull/13
- https://github.com/hylo-lang/hylo/pull/1800

See the action run from creating the distributable packages: https://github.com/hylo-lang/llvm-build/actions/runs/20003814931/job/57362991952

The resulting release: https://github.com/hylo-lang/llvm-build/releases/tag/20251207-115516


This should be squashed when merging.