### PR TITLE
Riscv and WebAssembly support

### DIFF
--- a/.github/workflows/llvm-binaries.yml
+++ b/.github/workflows/llvm-binaries.yml
@@ -119,11 +119,11 @@ jobs:
           # Extensions
           - arch: arm64
 
-            llvm_backend_libs: 'LLVMAArch64AsmParser;LLVMAArch64CodeGen;LLVMAArch64Desc;LLVMAArch64Disassembler;LLVMAArch64Info;LLVMAArch64Utils'
+            llvm_backend_libs: 'LLVMAArch64AsmParser;LLVMAArch64CodeGen;LLVMAArch64Desc;LLVMAArch64Disassembler;LLVMAArch64Info;LLVMAArch64Utils;LLVMRISCVAsmParser;LLVMRISCVCodeGen;LLVMRISCVDesc;LLVMRISCVDisassembler;LLVMRISCVInfo'
 
           - arch: x86_64
 
-            llvm_backend_libs: 'LLVMX86AsmParser;LLVMX86CodeGen;LLVMX86Desc;LLVMX86Disassembler;LLVMX86Info;LLVMX86TargetMCA'
+            llvm_backend_libs: 'LLVMX86AsmParser;LLVMX86CodeGen;LLVMX86Desc;LLVMX86Disassembler;LLVMX86Info;LLVMX86TargetMCA;LLVMRISCVAsmParser;LLVMRISCVCodeGen;LLVMRISCVDesc;LLVMRISCVDisassembler;LLVMRISCVInfo'
 
           - os: windows-2025
 
@@ -364,6 +364,15 @@ jobs:
           # Test llvm-config
           echo "Testing llvm-config..."
           "${{ github.workspace }}/BuildRoot/${{ env.PACKAGE_NAME }}/bin/llvm-config${{ matrix.executable_suffix }}" --version
+          
+          # Verify RISCV target support for ESP32-C3 cross compilation
+          echo "Checking RISCV target availability..."
+          if "${{ github.workspace }}/BuildRoot/${{ env.PACKAGE_NAME }}/bin/llc${{ matrix.executable_suffix }}" --version | grep -qi "riscv"; then
+            echo "RISCV target support detected."
+          else
+            echo "ERROR: RISCV target support was not found in this package."
+            # exit 1 todo add error if it works
+          fi
 
       - name: Make llvm.pc pkg-config file
         shell: bash

--- a/cmake/caches/LLVM.cmake
+++ b/cmake/caches/LLVM.cmake
@@ -7,7 +7,7 @@ set(ENABLE_X86_RELAX_RELOCATIONS YES CACHE BOOL "")
 set(LLVM_APPEND_VC_REV NO CACHE BOOL "")
 set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR YES CACHE BOOL "")
 
-set(LLVM_TARGETS_TO_BUILD AArch64 ARM WebAssembly X86 CACHE STRING "")
+set(LLVM_TARGETS_TO_BUILD AArch64 ARM RISCV WebAssembly X86 CACHE STRING "")
 
 # Disable certain targets to reduce the configure time or to avoid configuration
 # differences (and in some cases weird build errors on a complete build).


### PR DESCRIPTION
I'm experimenting with cross-compiling Hylo to embedded (RISCV esp32-c3) and WebAssembly. We need to rebuild LLVM with additional target support.